### PR TITLE
Make keyboard shortcut activate addon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
 
   "commands": {
-    "org-capture": {
+    "_execute_browser_action": {
       "description": "Capture current page with org-capture",
       "suggested_key": {
         "default": "Ctrl+Shift+L",


### PR DESCRIPTION
The add-on defined a shortcut to activate the "org-capture" command but wasn't listening for it anywhere. Changing it to `_execute_browser_action` makes it act as if a user had clicked the BrowserAction icon without any additional code.